### PR TITLE
Use more relaxed version requirement for Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "~6.2.1"
+    "guzzlehttp/guzzle": "^6.2.1"
   },
   "require-dev": {
     "phpunit/phpunit": "4.3.*"


### PR DESCRIPTION
The 6.2.x version of Guzzle does not work with PHP 7.2, so the requirement version requirement should be relaxed slightly to allow upgrading Guzzle.
