### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,15 @@ dist: trusty
 php:
   - 5.6
   - 5.5
-  - 7
+  - 7.0
+  - 7.1
+  - 7.2
   - hhvm
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 before_script:
-  - composer update
-
+  - composer install -n

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,16 @@
     "guzzlehttp/guzzle": "^6.2.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.3.*"
+    "phpunit/phpunit": "^4.8|^5.5|^6.5"
   },
   "autoload": {
     "psr-4": {
       "Pixabay\\": "src/Pixabay/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Pixabay\\Tests\\": "tests/"
     }
   }
 }

--- a/tests/PixabayClientTest.php
+++ b/tests/PixabayClientTest.php
@@ -14,14 +14,17 @@
  * @link     https://www.zoonman.com/projects/pixabay/
  */
  
-namespace Pixabay;
+namespace Pixabay\Tests;
+
+use Pixabay\PixabayClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PixabayClientTest
  *
  * @package Pixabay
  */
-class PixabayClientTest extends \PHPUnit_Framework_TestCase {
+class PixabayClientTest extends TestCase {
 
   /**
    * @var \Pixabay\PixabayClient
@@ -37,20 +40,30 @@ class PixabayClientTest extends \PHPUnit_Framework_TestCase {
     }
 
   /**
+    * Run tests
+    * @expectedException \Exception
+    * @expectedExceptionMessage You must specify "key" parameter in constructor options
+    */
+    public function testConstructorOnNoKeyParameter()
+    {
+        $this->object = new PixabayClient([]);
+    }
+
+  /**
    * Run tests
+   * @expectedException GuzzleHttp\Exception\ClientException
    */
     public function testGetImages()
     {
-        $this->setExpectedException('GuzzleHttp\Exception\ClientException');
         $this->assertInternalType('array', $this->object->getImages(['q' => 'test']));
     }
 
-    /**
+  /**
    * Run tests
+   * @expectedException GuzzleHttp\Exception\ClientException 
    */
     public function testGetVideos()
     {
-        $this->setExpectedException('GuzzleHttp\Exception\ClientException');
         $this->assertInternalType('array', $this->object->getVideos(['q' => 'test']));
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,4 +15,3 @@
  */
  
 require_once dirname(dirname(__FILE__)).'/vendor/autoload.php';
-require_once dirname(dirname(__FILE__)).'/src/Pixabay/PixabayClient.php';


### PR DESCRIPTION
# Changed log

- Add the ```php-7.1``` and ```php-7.2``` tests in Travis build.
- Add more tests.
- Set the different PHPUnit versions for supporting the multiple PHP versions.
- Using the ```expectedException``` annotation to be compatible with the different PHPUnit versions.