### PR TITLE
Upgrade Guzzle to 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "^6.2.1"
+    "php": ">=7.2",
+    "guzzlehttp/guzzle": "^6.0|^7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.5|^6.5"


### PR DESCRIPTION
Since Guzzle 7 requires PHP 7.2, I assumed the required PHP version should be updated as as well. Thanks a lot for your work!